### PR TITLE
 Add support for cip monster format

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Tibia OT Monster Converter is a tool for converting monster files between the va
 | [PyOT](https://bitbucket.org/vapus/pyot/)            | [0%](https://github.com/soul4soul/ot-monster-converter/wiki/PyOT-Input-Status)               | [90%](https://github.com/soul4soul/ot-monster-converter/wiki/PyOT-Output-Status)               | - This format can be consider dead as PyOT development has ceased. Unless development is picked back up support for this format is unlikely to be completed. |
 | TFS revscriptsys                                     | [0%](https://github.com/soul4soul/ot-monster-converter/wiki/TFS-revscriptsys-Input-Status)   | [95%](https://github.com/soul4soul/ot-monster-converter/wiki/TFS-revscriptsys-Output-Status)   | - Very new OT monster format that was theorized many years ago. In the future there is a good chance it will replace TFS XML completely. This is likely the output type that most users of this program will use. <br/> - Opentibiabr RevScriptSys format is not completely compatible with TFS RevScriptSys format |
 | [TibiaWiki](https://tibia.fandom.com/wiki/Main_Page) | [85%](https://github.com/soul4soul/ot-monster-converter/wiki/TibiaWiki-Input-Status)         | [70%](https://github.com/soul4soul/ot-monster-converter/wiki/TibiaWiki-Output-Status)          | - Helpful for keeping monsters up to date with cipbia<br/> - See The [Infobox Creature Template](https://tibia.fandom.com/wiki/Template:Infobox_Creature) for information about TibiaWiki Format <br/> - Monsters created from TibiaWiki will require corpse id, looktype, and spells to be created manually |
+| Cip Mon                                              | [95%](https://github.com/soul4soul/ot-monster-converter/wiki/Cip-Mon-Input-Status)           | [0%](https://github.com/soul4soul/ot-monster-converter/wiki/Cip-Mon-Output-Status)             | - Format is for input purposes to easily generte monsters as they were in the 7.7 days |
 
 ## Graphical User Interface
 
@@ -41,7 +42,7 @@ Options:
                                 otherwise flat folder structure is output
   -h, --help                 show this message and exit
 
-Input Formats: TFS XML, TibiaWiki
+Input Formats: Cip Mon, TFS XML, TibiaWiki
 Output Formats: TFS RevScriptSys, TibiaWiki, pyOT
 ```
 

--- a/app/MonsterConverterCipMon/CipMonConverter.cs
+++ b/app/MonsterConverterCipMon/CipMonConverter.cs
@@ -473,7 +473,7 @@ namespace MonsterConverterCipMon
                 {
                     SoundLevel volume = SoundLevel.Say;
                     string sound = match.Groups[1].Value;
-                    if (sound.StartsWith("#Y"))
+                    if (sound.StartsWith("#Y") || sound.StartsWith("#y"))
                     {
                         volume = SoundLevel.Yell;
                         sound = sound.Substring(3);

--- a/app/MonsterConverterCipMon/CipMonConverter.cs
+++ b/app/MonsterConverterCipMon/CipMonConverter.cs
@@ -288,6 +288,7 @@ namespace MonsterConverterCipMon
                     {
                         spell.Radius = int.Parse(castTypeParams[0]) + 1;
                         spell.AreaEffect = effectFromString(castTypeParams[1]);
+                        spell.OnTarget = false;
                     }
                     else if (castType == "destination")
                     {

--- a/app/MonsterConverterCipMon/CipMonConverter.cs
+++ b/app/MonsterConverterCipMon/CipMonConverter.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Composition;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace MonsterConverterCipMon
 {
@@ -20,10 +21,229 @@ namespace MonsterConverterCipMon
 
         public override bool IsWriteSupported { get => false; }
 
-        // Functions
-        public override ConvertResultEventArgs ReadMonster(string filename, out Monster monster)
+        // <race id, registered name>
+        private readonly IDictionary<int, string> raceIdNameMap = new Dictionary<int, string>();
+
+        /// <summary>
+        /// Not super efficient but we need a complete list of race ids ahead of time so we can map
+        /// them to monster names later. Since it's extremely likely we won't encounter the race ids in the order we need
+        /// them we need to get the fill list first.
+        /// </summary>
+        /// <param name="directory"></param>
+        /// <returns></returns>
+        public override string[] GetFilesForConversion(string directory)
         {
-            throw new NotImplementedException();
+            string[] fileList = base.GetFilesForConversion(directory);
+            foreach (string file in fileList)
+            {
+                string registeredName = Path.GetFileNameWithoutExtension(file);
+                string fileContents = File.ReadAllText(file);
+
+                Match m = Regex.Match(fileContents, @"RaceNumber\s+= (\d+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+                if (m.Success) {
+                    int raceId = int.Parse(m.Value);
+                    raceIdNameMap.Add(raceId, registeredName);
+                }
+            }
+
+            return fileList;
+        }
+
+        // Functions
+        public override ConvertResultEventArgs ReadMonster(string fileName, out Monster monster)
+        {
+            ConvertResultEventArgs result = new ConvertResultEventArgs(fileName);
+
+            monster = new Monster();
+            monster.FileName = monster.RegisteredName = Path.GetFileNameWithoutExtension(fileName);
+
+            string fileContents = File.ReadAllText(fileName);
+
+            Match m = Regex.Match(fileContents, @"RaceNumber\s+= (\d+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success) { monster.RaceId = int.Parse(m.Value); }
+
+            m = Regex.Match(fileContents, @"Name\s+= ""(.*?)""", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success) { monster.Name = m.Value; }
+
+            m = Regex.Match(fileContents, @"/Article\s+= ""(\S+)""", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success)
+            {
+                if (string.IsNullOrWhiteSpace(m.Value))
+                {
+                    monster.Description = monster.Name;
+                }
+                else
+                {
+                    monster.Description = string.Format("{0} {1}", m.Value.ToLower(), monster.Name).Trim();
+                }
+            }
+
+            m = Regex.Match(fileContents, @"/Corpse\s+= ""(\d+)""", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success) { monster.Look.CorpseId = int.Parse(m.Value); }
+
+            m = Regex.Match(fileContents, @"Outfit\s+= \((?<type>\d+), (?<head>\d+)-(?<body>\d+)-(?<legs>\d+)-(?<feet>\d+)\)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success)
+            {
+                monster.Look.LookType = LookType.Outfit;
+                monster.Look.LookId = int.Parse(m.Groups["type"].Value);
+                monster.Look.Head = int.Parse(m.Groups["head"].Value);
+                monster.Look.Body = int.Parse(m.Groups["body"].Value);
+                monster.Look.Legs = int.Parse(m.Groups["legs"].Value);
+                monster.Look.Feet = int.Parse(m.Groups["feet"].Value);
+            }
+
+            m = Regex.Match(fileContents, @"Outfit\s+= \((?<type>\d+), (?<id>\d+)\)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success)
+            {
+                int type = int.Parse(m.Groups["type"].Value);
+                int id = int.Parse(m.Groups["id"].Value);
+                if ((type == 0) && (id == 0))
+                {
+                    monster.Look.LookType = LookType.Invisible;
+                }
+                else
+                {
+                    monster.Look.LookType = LookType.Item;
+                    monster.Look.LookId = int.Parse(m.Groups["type"].Value);
+                }
+            }
+
+            m = Regex.Match(fileContents, @"Blood\s+= (\S+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success)
+            {
+                if (string.Equals(m.Value, "blood", StringComparison.OrdinalIgnoreCase))
+                {
+                    monster.Race = Blood.blood;
+                }
+                else if (string.Equals(m.Value, "slime", StringComparison.OrdinalIgnoreCase))
+                {
+                    monster.Race = Blood.venom;
+                }
+                else if (string.Equals(m.Value, "fire", StringComparison.OrdinalIgnoreCase))
+                {
+                    monster.Race = Blood.fire;
+                }
+                else if (string.Equals(m.Value, "bones", StringComparison.OrdinalIgnoreCase))
+                {
+                    monster.Race = Blood.undead;
+                }
+            }
+
+            m = Regex.Match(fileContents, @"Experience\s+= (\d+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success) { monster.Experience = int.Parse(m.Value); }
+
+            m = Regex.Match(fileContents, @"SummonCost\s+= (\d+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            int summonCost = 0;
+            if (m.Success) { summonCost = int.Parse(m.Value); }
+            if (!fileContents.Contains("NoSummon", StringComparison.OrdinalIgnoreCase)) { monster.SummonCost = summonCost; }
+            if (!fileContents.Contains("NoConvince", StringComparison.OrdinalIgnoreCase)) { monster.ConvinceCost = summonCost; }
+
+            m = Regex.Match(fileContents, @"Defend\s+= (\d+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success) { monster.Shielding = int.Parse(m.Value); }
+
+            m = Regex.Match(fileContents, @"Armor\s+= (\d+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success) { monster.TotalArmor = int.Parse(m.Value); }
+
+            //m = Regex.Match(fileContents, @"Poison\s+= (\d+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+            m = Regex.Match(fileContents, @"LoseTarget\s+= (\d+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success) { monster.RetargetChance = int.Parse(m.Value) / 100.0; }
+
+            m = Regex.Match(fileContents, @"FleeThreshold\s+= (\d+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success) { monster.RunOnHealth = int.Parse(m.Value); }
+
+            m = Regex.Match(fileContents, @"HitPoints, (\d+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success) { monster.Health = int.Parse(m.Value); }
+
+            m = Regex.Match(fileContents, @"Strategy\s+= \((?<closest>\d+), (?<weakest>\d+), (?<strongest>\d+), (?<random>\d+)\)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success)
+            {
+                monster.TargetStrategy.Closest = int.Parse(m.Groups["closest"].Value);
+                monster.TargetStrategy.Weakest = int.Parse(m.Groups["weakest"].Value);
+                monster.TargetStrategy.Strongest = int.Parse(m.Groups["strongest"].Value);
+                monster.TargetStrategy.Random = int.Parse(m.Groups["random"].Value);
+            }
+
+            monster.IsPushable = !fileContents.Contains("Unpushable", StringComparison.OrdinalIgnoreCase);
+            monster.PushItems = fileContents.Contains("KickBoxes", StringComparison.OrdinalIgnoreCase);
+            monster.PushCreatures = fileContents.Contains("KickCreatures", StringComparison.OrdinalIgnoreCase);
+            monster.IgnoreInvisible = fileContents.Contains("SeeInvisible", StringComparison.OrdinalIgnoreCase);
+            monster.IgnoreParalyze = fileContents.Contains("NoParalyze", StringComparison.OrdinalIgnoreCase);
+            monster.IsIllusionable = !fileContents.Contains("NoIllusion", StringComparison.OrdinalIgnoreCase);
+            monster.TargetDistance = fileContents.Contains("DistanceFighting", StringComparison.OrdinalIgnoreCase) ? 4 : 1;
+
+            if (fileContents.Contains("NoHit", StringComparison.OrdinalIgnoreCase)) { monster.PhysicalDmgMod = 0; }
+            if (fileContents.Contains("NoBurning", StringComparison.OrdinalIgnoreCase)) { monster.FireDmgMod = 0; }
+            if (fileContents.Contains("NoPoison", StringComparison.OrdinalIgnoreCase)) { monster.EarthDmgMod = 0; }
+            if (fileContents.Contains("NoEnergy", StringComparison.OrdinalIgnoreCase)) { monster.EnergyDmgMod = 0; }
+            if (fileContents.Contains("NoLifeDrain", StringComparison.OrdinalIgnoreCase)) { monster.LifeDrainDmgMod = 0; }
+
+            m = Regex.Match(fileContents, @"GoStrength, (\d+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            monster.Speed = (m.Success) ? monster.Speed = int.Parse(m.Value) + 120 : 0;
+
+            m = Regex.Match(fileContents, @"Attack\s+= (\d+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            int attack = 0;
+            if (m.Success) { attack = int.Parse(m.Value); }
+            monster.IsHostile = (attack != 0);
+
+            m = Regex.Match(fileContents, @"FistFighting, (\d+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            int skill = 0;
+            if (m.Success) { skill = int.Parse(m.Value); }
+
+            if ((attack != 0) && (skill != 0))
+            {
+                Spell meleeAttack = new Spell()
+                {
+                    Name = "melee",
+                    Interval = 2000,
+                    Chance = 100,
+                    Range = 1,
+                    AttackValue = attack,
+                    Skill = skill
+                };
+                monster.Attacks.Add(meleeAttack);
+            }
+
+            m = Regex.Match(fileContents, @"Spells.*?= \{(.*?)\}", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success)
+            {
+                var matches = Regex.Matches(m.Value, @"(\S+) \((.*?)\) -\> (\S+) \((.*?)\) \: (\d+)", RegexOptions.Singleline);
+                // TODO parse abilities
+            }
+
+            m = Regex.Match(fileContents, @"Talk.*?= \{(.*?)\}", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success)
+            {
+                var matches = Regex.Matches(m.Value, @"""(.*?)""", RegexOptions.Singleline);
+                foreach (Match match in matches)
+                {
+                    SoundLevel volume = SoundLevel.Say;
+                    string sound = match.Value;
+                    if (sound.StartsWith("#Y"))
+                    {
+                        volume = SoundLevel.Yell;
+                        sound = match.Value.Substring(2);
+                    }
+                    monster.Voices.Add(new Voice(sound, volume));
+                }
+            }
+
+            m = Regex.Match(fileContents, @"Inventory.*?= \{(.*?)\}", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (m.Success)
+            {
+                var matches = Regex.Matches(m.Value, @"\((?<id>\d+), (?<count>\d+), (?<chance>\d+)\)", RegexOptions.Singleline);
+                foreach (Match match in matches)
+                {
+                    monster.Items.Add(new Loot()
+                    {
+                        Item = match.Groups["id"].Value,
+                        Count = int.Parse(match.Groups["count"].Value),
+                        Chance = decimal.Parse(match.Groups["id"].Value) / 1000
+                    });
+                }
+            }
+
+            return result;
         }
 
         public override ConvertResultEventArgs WriteMonster(string directory, ref Monster monster)

--- a/app/MonsterConverterCipMon/CipMonConverter.cs
+++ b/app/MonsterConverterCipMon/CipMonConverter.cs
@@ -1,0 +1,34 @@
+﻿using MonsterConverterInterface;
+using MonsterConverterInterface.MonsterTypes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace MonsterConverterCipMon
+{
+    [Export(typeof(IMonsterConverter))]
+    public class CipMonConverter : MonsterConverter
+    {
+        public override string ConverterName { get => "CipMon"; }
+
+        public override string FileExt { get => "mon"; }
+
+        public override bool IsReadSupported { get => true; }
+
+        public override bool IsWriteSupported { get => false; }
+
+        // Functions
+        public override ConvertResultEventArgs ReadMonster(string filename, out Monster monster)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override ConvertResultEventArgs WriteMonster(string directory, ref Monster monster)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/app/MonsterConverterCipMon/MonsterConverterCipMon.csproj
+++ b/app/MonsterConverterCipMon/MonsterConverterCipMon.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputPath>..\..\bin\$(Configuration)</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>..\..\bin\$(Configuration)</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.9.20" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MonsterConverterInterface\MonsterConverterInterface.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/app/MonsterConverterInterface/Enums/LookType.cs
+++ b/app/MonsterConverterInterface/Enums/LookType.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MonsterConverterInterface.MonsterTypes
+{
+    public enum LookType
+    {
+        Outfit,
+        Item,
+        Invisible
+    }
+}

--- a/app/MonsterConverterInterface/MonsterTypes/LookData.cs
+++ b/app/MonsterConverterInterface/MonsterTypes/LookData.cs
@@ -4,39 +4,46 @@ using System.Text;
 
 namespace MonsterConverterInterface.MonsterTypes
 {
-    //todo should we add outfit ID to this class?
-    public class DetailedLookType
+    public class LookData
     {
         // Variables
-        private const ushort MAX_COLOR = 132;
+        private const int MAX_COLOR = 132;
 
-        private ushort _Head;
-        private ushort _Body;
-        private ushort _Legs;
-        private ushort _Feet;
+        private int _Head;
+        private int _Body;
+        private int _Legs;
+        private int _Feet;
 
         // Properties
-        public ushort Head
+        public LookType LookType { get; set; }
+
+        public int LookId { get; set; }
+
+        public int CorpseId { get; set; }
+
+        public int Head
         {
             get { return _Head; }
             set { _Head = (value > MAX_COLOR) ? MAX_COLOR : value; }
         }
-        public ushort Body
+        public int Body
         {
             get { return _Body; }
             set { _Body = (value > MAX_COLOR) ? MAX_COLOR : value; }
         }
-        public ushort Legs
+        public int Legs
         {
             get { return _Legs; }
             set { _Legs = (value > MAX_COLOR) ? MAX_COLOR : value; }
         }
-        public ushort Feet
+        public int Feet
         {
             get { return _Feet; }
             set { _Feet = (value > MAX_COLOR) ? MAX_COLOR : value; }
         }
-        public ushort Addons { get; set; }
-        public ushort Mount { get; set; }
+
+        public int Addons { get; set; }
+
+        public int Mount { get; set; }
     }
 }

--- a/app/MonsterConverterInterface/MonsterTypes/Monster.cs
+++ b/app/MonsterConverterInterface/MonsterTypes/Monster.cs
@@ -94,6 +94,7 @@ namespace MonsterConverterInterface.MonsterTypes
         public int LightColor { get; set; }
         public bool HideHealth { get; set; }
         public bool IsBoss { get; set; }
+        public int RaceId { get; set; }
 
         // Behavior
         public bool IsPushable { get; set; }

--- a/app/MonsterConverterInterface/MonsterTypes/Monster.cs
+++ b/app/MonsterConverterInterface/MonsterTypes/Monster.cs
@@ -13,7 +13,7 @@ namespace MonsterConverterInterface.MonsterTypes
             MaxSummons = 0;
             Summons = new List<Summon>();
             Items = new List<Loot>();
-            LookTypeDetails = new DetailedLookType();
+            Look = new LookData();
             Attacks = new List<Spell>();
             Scripts = new List<Script>();
 
@@ -82,12 +82,7 @@ namespace MonsterConverterInterface.MonsterTypes
         public Blood Race { get; set; }
         public int MaxSummons { get; set; }
         public IList<Summon> Summons { get; }
-
-        // Look
-        public int CorpseId { get; set; }
-        public int OutfitIdLookType { get; set; }
-        public int ItemIdLookType { get; set; } // non 0 means creature looks like an item
-        public DetailedLookType LookTypeDetails { get; }
+        public LookData Look { get; }
 
         // Other
         public int SummonCost { get; set; }

--- a/app/MonsterConverterInterface/MonsterTypes/Monster.cs
+++ b/app/MonsterConverterInterface/MonsterTypes/Monster.cs
@@ -18,6 +18,7 @@ namespace MonsterConverterInterface.MonsterTypes
             Scripts = new List<Script>();
             TargetStrategy = new TargetStrategy();
 
+            RetargetInterval = 2000;
             SummonCost = 0;
             Attackable = true;
             IsHostile = true;
@@ -143,5 +144,10 @@ namespace MonsterConverterInterface.MonsterTypes
 
         // Attached Scripts
         public IList<Script> Scripts { get; }
+
+        public override string ToString()
+        {
+            return $"{RegisteredName} (HP:{Health}, EXP:{Experience})";
+        }
     }
 }

--- a/app/MonsterConverterInterface/MonsterTypes/Monster.cs
+++ b/app/MonsterConverterInterface/MonsterTypes/Monster.cs
@@ -16,6 +16,7 @@ namespace MonsterConverterInterface.MonsterTypes
             Look = new LookData();
             Attacks = new List<Spell>();
             Scripts = new List<Script>();
+            TargetStrategy = new TargetStrategy();
 
             SummonCost = 0;
             Attackable = true;
@@ -104,6 +105,7 @@ namespace MonsterConverterInterface.MonsterTypes
         public int TargetDistance { get; set; }
         public int RunOnHealth { get; set; }
         public int StaticAttackChance { get; set; } // Static attack controls how much the monster dances/moves when attacking a target, 100 = completely static, 0 = always dance
+        public TargetStrategy TargetStrategy { get; }
 
         // Walk Behavior
         public bool AvoidFire { get; set; }

--- a/app/MonsterConverterInterface/MonsterTypes/Monster.cs
+++ b/app/MonsterConverterInterface/MonsterTypes/Monster.cs
@@ -19,14 +19,14 @@ namespace MonsterConverterInterface.MonsterTypes
 
             SummonCost = 0;
             Attackable = true;
-            Hostile = true;
-            Illusionable = false;
+            IsHostile = true;
+            IsIllusionable = false;
             ConvinceCost = 0;
-            Pushable = false;
+            IsPushable = false;
             PushItems = false;
             PushCreatures = false;
             TargetDistance = 1;
-            StaticAttack = 95;
+            StaticAttackChance = 90;
             LightLevel = 0;
             LightColor = 0;
             RunOnHealth = 0;
@@ -78,35 +78,37 @@ namespace MonsterConverterInterface.MonsterTypes
         public int Health { get; set; }
         public int Experience { get; set; }
         public int Speed { get; set; }
-        public IList<Voice> Voices { get; set; }
+        public IList<Voice> Voices { get; }
         public Blood Race { get; set; }
-        public int RetargetInterval { get; set; }
-        public double RetargetChance { get; set; }
         public int MaxSummons { get; set; }
-        public IList<Summon> Summons { get; set; }
+        public IList<Summon> Summons { get; }
 
         // Look
         public int CorpseId { get; set; }
         public int OutfitIdLookType { get; set; }
         public int ItemIdLookType { get; set; } // non 0 means creature looks like an item
-        public DetailedLookType LookTypeDetails { get; set; }
+        public DetailedLookType LookTypeDetails { get; }
 
-        // Behavior
+        // Other
         public int SummonCost { get; set; }
         public bool Attackable { get; set; }
-        public bool Hostile { get; set; }
-        public bool Illusionable { get; set; }
+        public bool IsIllusionable { get; set; }
         public int ConvinceCost { get; set; }
-        public bool Pushable { get; set; }
-        public bool PushItems { get; set; }
-        public bool PushCreatures { get; set; }
-        public int TargetDistance { get; set; }
-        public int RunOnHealth { get; set; }
-        public int StaticAttack { get; set; }
         public int LightLevel { get; set; }
         public int LightColor { get; set; }
         public bool HideHealth { get; set; }
         public bool IsBoss { get; set; }
+
+        // Behavior
+        public bool IsPushable { get; set; }
+        public bool PushItems { get; set; }
+        public bool PushCreatures { get; set; }
+        public bool IsHostile { get; set; }
+        public int RetargetInterval { get; set; }
+        public double RetargetChance { get; set; }
+        public int TargetDistance { get; set; }
+        public int RunOnHealth { get; set; }
+        public int StaticAttackChance { get; set; } // Static attack controls how much the monster dances/moves when attacking a target, 100 = completely static, 0 = always dance
 
         // Walk Behavior
         public bool AvoidFire { get; set; }
@@ -114,7 +116,7 @@ namespace MonsterConverterInterface.MonsterTypes
         public bool AvoidPoison { get; set; }
 
         // Attacks
-        public IList<Spell> Attacks { get; set; }
+        public IList<Spell> Attacks { get; }
 
         // Defeneses
         public int TotalArmor { get; set; }
@@ -139,9 +141,9 @@ namespace MonsterConverterInterface.MonsterTypes
         public bool IgnoreBleed { get; set; }
 
         // Loot
-        public IList<Loot> Items { get; set; }
+        public IList<Loot> Items { get; }
 
         // Attached Scripts
-        public IList<Script> Scripts { get; set; }
+        public IList<Script> Scripts { get; }
     }
 }

--- a/app/MonsterConverterInterface/MonsterTypes/Spell.cs
+++ b/app/MonsterConverterInterface/MonsterTypes/Spell.cs
@@ -7,6 +7,7 @@ namespace MonsterConverterInterface.MonsterTypes
     public class Spell
     {
         public string Name { get; set; }
+        public string Description { get; set; }
         public SpellCategory SpellCategory { get; set; }
         public int? MinDamage { get; set; }
         public int? MaxDamage { get; set; }
@@ -39,5 +40,11 @@ namespace MonsterConverterInterface.MonsterTypes
         public int? ItemId { get; set; }
         // Drunk
         public double? Drunkenness { get; set; }
+
+        public override string ToString()
+        {
+            string category = (SpellCategory == SpellCategory.Offensive) ? "Offenseive" : "Defensive";
+            return $"{category}: {Name} ({Description})";
+        }
     }
 }

--- a/app/MonsterConverterInterface/MonsterTypes/Spell.cs
+++ b/app/MonsterConverterInterface/MonsterTypes/Spell.cs
@@ -7,6 +7,11 @@ namespace MonsterConverterInterface.MonsterTypes
     public class Spell
     {
         public string Name { get; set; }
+        /// <summary>
+        /// Free form string field not used by any engine, information stored here is useful for maintaining a server
+        /// For example, it puts a short description to a spell "demon giant gfb"
+        /// etc..
+        /// </summary>
         public string Description { get; set; }
         public SpellCategory SpellCategory { get; set; }
         public int? MinDamage { get; set; }

--- a/app/MonsterConverterInterface/MonsterTypes/TargetStrategy.cs
+++ b/app/MonsterConverterInterface/MonsterTypes/TargetStrategy.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MonsterConverterInterface.MonsterTypes
+{
+    public class TargetStrategy
+    {
+        public int Closest { get; set; }
+        public int Weakest { get; set; }
+        public int Strongest { get; set; }
+        public int Random { get; set; } = 100;
+    }
+}

--- a/app/MonsterConverterInterface/MonsterTypes/Voice.cs
+++ b/app/MonsterConverterInterface/MonsterTypes/Voice.cs
@@ -6,6 +6,12 @@ namespace MonsterConverterInterface.MonsterTypes
 {
     public class Voice
     {
+        public Voice(string sound, SoundLevel volume = SoundLevel.Say)
+        {
+            Sound = sound;
+            SoundLevel = volume;
+        }
+
         public string Sound { get; set; }
         public SoundLevel SoundLevel { get; set; }
     }

--- a/app/MonsterConverterPyOt/PyOtConverter.cs
+++ b/app/MonsterConverterPyOt/PyOtConverter.cs
@@ -42,7 +42,7 @@ namespace MonsterConverterPyOt
                 string.Format("{0}.setSpeed({1})", lowerName, monster.Speed),
                 //string.Format("{0}.setTargetChance({1})", lowerName, monster.RetargetChance), //Currently unused in pyOT?, consider changing code in pyOT to be chance of 0 to 1 for a percent instead of 0 to 100
                 string.Format("{0}.behavior(summonable={1}, hostile={2}, illusionable={3}, convinceable={4}, pushable={5}, pushItems={6}, pushCreatures={7}, targetDistance={8}, runOnHealth={9}, targetChange={10})",
-                    lowerName, monster.SummonCost, monster.Hostile, monster.Illusionable, monster.ConvinceCost, monster.Pushable, monster.PushItems, monster.PushCreatures, monster.TargetDistance, monster.RunOnHealth, 1),
+                    lowerName, monster.SummonCost, monster.IsHostile, monster.IsIllusionable, monster.ConvinceCost, monster.IsPushable, monster.PushItems, monster.PushCreatures, monster.TargetDistance, monster.RunOnHealth, 1),
                 string.Format("{0}.walkAround(energy={1}, fire={2}, poison={3})", lowerName, monster.AvoidEnergy, monster.AvoidFire, monster.AvoidPoison),
                 string.Format("{0}.immunity(paralyze={1}, invisible={2}, drunk={3})",
                     lowerName, monster.IgnoreParalyze, monster.IgnoreInvisible, monster.IgnoreDrunk),

--- a/app/MonsterConverterPyOt/PyOtConverter.cs
+++ b/app/MonsterConverterPyOt/PyOtConverter.cs
@@ -33,7 +33,7 @@ namespace MonsterConverterPyOt
 
             string[] lines =
             {
-                string.Format("{0} = genMonster(\"{1}\", ({2}, {3}), \"{4}\")", lowerName, monster.Name, monster.CorpseId, monster.OutfitIdLookType, monster.Description),
+                string.Format("{0} = genMonster(\"{1}\", ({2}, {3}), \"{4}\")", lowerName, monster.Name, monster.Look.CorpseId, monster.Look.LookId, monster.Description),
                 string.Format("{0}.health({1})", lowerName, monster.Health),
                 string.Format("{0}.bloodType({1})", lowerName, GenericToPyOTBlood(monster.Race)), //todo might change
                 string.Format("{0}.defense(armor={1}, fire={2}, earth={3}, energy={4}, ice={5}, holy={6}, death={7}, physical={8}, drown={9}, lifedrain={10}, manadrain={11})",

--- a/app/MonsterConverterPyOt/PyOtConverter.cs
+++ b/app/MonsterConverterPyOt/PyOtConverter.cs
@@ -7,7 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 
-namespace MonsterConverterPyOt.Converter
+namespace MonsterConverterPyOt
 {
     // https://bitbucket.org/vapus/pyot/src/0aa7c38f46814f502f375b84ac905e7f5ebef1a3/game/monster.py?at=default
     [Export(typeof(IMonsterConverter))]

--- a/app/MonsterConverterTfsRevScriptSys/TfsRevScriptSysConverter.cs
+++ b/app/MonsterConverterTfsRevScriptSys/TfsRevScriptSysConverter.cs
@@ -239,7 +239,7 @@ namespace MonsterConverterTfsRevScriptSys
                 {
                     dest.WriteLine($"	lookTypeEx = {monster.Look.LookId}");
                 }
-                else if (monster.Look.LookType == LookType.Item)
+                else if (monster.Look.LookType == LookType.Outfit)
                 {
                     dest.WriteLine($"	lookType = {monster.Look.LookId},");
                     dest.WriteLine($"	lookHead = {monster.Look.Head},");
@@ -249,7 +249,7 @@ namespace MonsterConverterTfsRevScriptSys
                     dest.WriteLine($"	lookAddons = {monster.Look.Addons},");
                     dest.WriteLine($"	lookMount = {monster.Look.Mount}");
                 }
-                else
+                else if (monster.Look.LookType == LookType.Invisible)
                 {
                     result.IncreaseError(ConvertError.Warning);
                     result.AppendMessage("Invisible look type not supported");

--- a/app/MonsterConverterTfsRevScriptSys/TfsRevScriptSysConverter.cs
+++ b/app/MonsterConverterTfsRevScriptSys/TfsRevScriptSysConverter.cs
@@ -235,19 +235,24 @@ namespace MonsterConverterTfsRevScriptSys
                 dest.WriteLine($"monster.description = \"{monster.Description}\"");
                 dest.WriteLine($"monster.experience = {monster.Experience}");
                 dest.WriteLine("monster.outfit = {");
-                if (monster.ItemIdLookType != 0)
+                if (monster.Look.LookType == LookType.Item)
                 {
-                    dest.WriteLine($"	lookTypeEx = {monster.ItemIdLookType}");
+                    dest.WriteLine($"	lookTypeEx = {monster.Look.LookId}");
+                }
+                else if (monster.Look.LookType == LookType.Item)
+                {
+                    dest.WriteLine($"	lookType = {monster.Look.LookId},");
+                    dest.WriteLine($"	lookHead = {monster.Look.Head},");
+                    dest.WriteLine($"	lookBody = {monster.Look.Body},");
+                    dest.WriteLine($"	lookLegs = {monster.Look.Legs},");
+                    dest.WriteLine($"	lookFeet = {monster.Look.Feet},");
+                    dest.WriteLine($"	lookAddons = {monster.Look.Addons},");
+                    dest.WriteLine($"	lookMount = {monster.Look.Mount}");
                 }
                 else
                 {
-                    dest.WriteLine($"	lookType = {monster.OutfitIdLookType},");
-                    dest.WriteLine($"	lookHead = {monster.LookTypeDetails.Head},");
-                    dest.WriteLine($"	lookBody = {monster.LookTypeDetails.Body},");
-                    dest.WriteLine($"	lookLegs = {monster.LookTypeDetails.Legs},");
-                    dest.WriteLine($"	lookFeet = {monster.LookTypeDetails.Feet},");
-                    dest.WriteLine($"	lookAddons = {monster.LookTypeDetails.Addons},");
-                    dest.WriteLine($"	lookMount = {monster.LookTypeDetails.Mount}");
+                    result.IncreaseError(ConvertError.Warning);
+                    result.AppendMessage("Invisible look type not supported");
                 }
                 dest.WriteLine("}");
                 dest.WriteLine("");
@@ -255,7 +260,7 @@ namespace MonsterConverterTfsRevScriptSys
                 dest.WriteLine($"monster.maxHealth = {monster.Health}");
                 dest.WriteLine($"monster.runHealth = {monster.RunOnHealth}");
                 dest.WriteLine($"monster.race = \"{BloodToRace[monster.Race]}\"");
-                dest.WriteLine($"monster.corpse = {monster.CorpseId}");
+                dest.WriteLine($"monster.corpse = {monster.Look.CorpseId}");
                 dest.WriteLine($"monster.speed = {monster.Speed}");
                 dest.WriteLine($"monster.summonCost = {monster.SummonCost}");
                 dest.WriteLine($"monster.maxSummons = {monster.MaxSummons}");

--- a/app/MonsterConverterTfsRevScriptSys/TfsRevScriptSysConverter.cs
+++ b/app/MonsterConverterTfsRevScriptSys/TfsRevScriptSysConverter.cs
@@ -270,15 +270,15 @@ namespace MonsterConverterTfsRevScriptSys
                 // Flags
                 dest.WriteLine("monster.flags = {");
                 dest.WriteLine($"	attackable = {monster.Attackable.ToString().ToLower()},");
-                dest.WriteLine($"	hostile = {monster.Hostile.ToString().ToLower()},");
+                dest.WriteLine($"	hostile = {monster.IsHostile.ToString().ToLower()},");
                 dest.WriteLine($"	summonable = {(monster.SummonCost > 0).ToString().ToLower()},");
                 dest.WriteLine($"	convinceable = {(monster.ConvinceCost > 0).ToString().ToLower()},");
-                dest.WriteLine($"	illusionable = {monster.Illusionable.ToString().ToLower()},");
+                dest.WriteLine($"	illusionable = {monster.IsIllusionable.ToString().ToLower()},");
                 dest.WriteLine($"	boss = {monster.IsBoss.ToString().ToLower()},");
-                dest.WriteLine($"	pushable = {monster.Pushable.ToString().ToLower()},");
+                dest.WriteLine($"	pushable = {monster.IsPushable.ToString().ToLower()},");
                 dest.WriteLine($"	canPushItems = {monster.PushItems.ToString().ToLower()},");
                 dest.WriteLine($"	canPushCreatures = {monster.PushCreatures.ToString().ToLower()},");
-                dest.WriteLine($"	staticAttackChance = {monster.StaticAttack},");
+                dest.WriteLine($"	staticAttackChance = {monster.StaticAttackChance},");
                 dest.WriteLine($"	targetDistance = {monster.TargetDistance},");
                 dest.WriteLine($"	healthHidden = {monster.HideHealth.ToString().ToLower()},");
                 dest.WriteLine($"	canWalkOnEnergy = {(!monster.AvoidEnergy).ToString().ToLower()},");

--- a/app/MonsterConverterTfsXml/TfsXmlConverter.cs
+++ b/app/MonsterConverterTfsXml/TfsXmlConverter.cs
@@ -304,18 +304,28 @@ namespace MonsterConverterTfsXml
 
             if (tfsMonster.look != null)
             {
-                monster.CorpseId = tfsMonster.look.corpse;
-                monster.OutfitIdLookType = tfsMonster.look.type;
-                monster.LookTypeDetails = new DetailedLookType()
+                if (tfsMonster.look.type != 0)
                 {
-                    Head = (ushort)tfsMonster.look.head,
-                    Body = (ushort)tfsMonster.look.body,
-                    Legs = (ushort)tfsMonster.look.legs,
-                    Feet = (ushort)tfsMonster.look.feet,
-                    Addons = (ushort)tfsMonster.look.addons,
-                    Mount = (ushort)tfsMonster.look.mount
-                };
-                monster.ItemIdLookType = tfsMonster.look.typeex;
+                    monster.Look.LookType = LookType.Outfit;
+                    monster.Look.LookId = tfsMonster.look.type;
+                    monster.Look.Head = tfsMonster.look.head;
+                    monster.Look.Body = tfsMonster.look.body;
+                    monster.Look.Legs = tfsMonster.look.legs;
+                    monster.Look.Feet = tfsMonster.look.feet;
+                    monster.Look.Addons = tfsMonster.look.addons;
+                    monster.Look.Mount = tfsMonster.look.mount;
+                }
+                else if (tfsMonster.look.typeex != 0)
+                {
+                    monster.Look.LookType = LookType.Item;
+                    monster.Look.LookId = tfsMonster.look.typeex;
+                }
+                else
+                {
+                    monster.Look.LookType = LookType.Invisible;
+                }
+
+                monster.Look.CorpseId = tfsMonster.look.corpse;
             }
 
             // flags

--- a/app/MonsterConverterTfsXml/TfsXmlConverter.cs
+++ b/app/MonsterConverterTfsXml/TfsXmlConverter.cs
@@ -337,11 +337,11 @@ namespace MonsterConverterTfsXml
                         }
                         else if (x.attr[0].Name == "hostile")
                         {
-                            monster.Hostile = value == 1;
+                            monster.IsHostile = value == 1;
                         }
                         else if (x.attr[0].Name == "illusionable")
                         {
-                            monster.Illusionable = value == 1;
+                            monster.IsIllusionable = value == 1;
                         }
                         else if (x.attr[0].Name == "convinceable")
                         {
@@ -349,7 +349,7 @@ namespace MonsterConverterTfsXml
                         }
                         else if (x.attr[0].Name == "pushable")
                         {
-                            monster.Pushable = value == 1;
+                            monster.IsPushable = value == 1;
                         }
                         else if (x.attr[0].Name == "canpushitems")
                         {
@@ -365,7 +365,7 @@ namespace MonsterConverterTfsXml
                         }
                         else if (x.attr[0].Name == "staticattack")
                         {
-                            monster.StaticAttack = value;
+                            monster.StaticAttackChance = value;
                         }
                         else if (x.attr[0].Name == "lightlevel")
                         {

--- a/app/MonsterConverterTfsXml/TfsXmlConverter.cs
+++ b/app/MonsterConverterTfsXml/TfsXmlConverter.cs
@@ -423,8 +423,7 @@ namespace MonsterConverterTfsXml
             {
                 foreach (VoiceXml sound in tfsMonster.voices.voice)
                 {
-                    Voice voice = new Voice();
-                    voice.Sound = sound.sentence;
+                    Voice voice = new Voice(sound.sentence);
                     if (!(string.IsNullOrEmpty(sound.yell)) &&
                         ((sound.yell == "1") || (sound.yell == "true")))
                     {

--- a/app/MonsterConverterTibiaWiki/TibiaWikiConverter.cs
+++ b/app/MonsterConverterTibiaWiki/TibiaWikiConverter.cs
@@ -1037,6 +1037,7 @@ namespace MonsterConverterTibiaWiki
             if (RobustTryParse(creature.HealMod, out intVal)) { monster.HealingMod = intVal / 100.0; }
             if (RobustTryParse(creature.LifeDrainDmgMod, out intVal)) { monster.LifeDrainDmgMod = intVal / 100.0; }
             if (RobustTryParse(creature.DrownDmgMod, out intVal)) { monster.DrownDmgMod = intVal / 100.0; }
+            if (RobustTryParse(creature.RaceId, out intVal)) { monster.RaceId = intVal; }
             if (!string.IsNullOrWhiteSpace(creature.Sounds)) { ParseSoundList(monster, creature.Sounds); }
             if (!string.IsNullOrWhiteSpace(creature.Behavior)) { ParseBehavior(monster, creature.Behavior); }
             if (!string.IsNullOrWhiteSpace(creature.Abilities)) { ParseAbilities(monster, creature.Abilities); }

--- a/app/MonsterConverterTibiaWiki/TibiaWikiConverter.cs
+++ b/app/MonsterConverterTibiaWiki/TibiaWikiConverter.cs
@@ -300,7 +300,10 @@ namespace MonsterConverterTibiaWiki
                     {
                         // Sometimes unknow sound templates include a single empty sound {{SoundList|}}
                         if (!string.IsNullOrWhiteSpace(sound))
-                            mon.Voices.Add(new Voice() { Sound = sound, SoundLevel = SoundLevel.Say });
+                        {
+                            // TibiaWiki doesn't include sound level information, default to say
+                            mon.Voices.Add(new Voice(sound, SoundLevel.Say));
+                        }
                     }
                 }
             }

--- a/app/MonsterConverterTibiaWiki/TibiaWikiConverter.cs
+++ b/app/MonsterConverterTibiaWiki/TibiaWikiConverter.cs
@@ -1017,10 +1017,10 @@ namespace MonsterConverterTibiaWiki
             if (!string.IsNullOrWhiteSpace(creature.RunsAt)) { ParseRunAt(monster, creature.RunsAt); }
             if (RobustTryParse(creature.Summon, out intVal)) { monster.SummonCost = intVal; }
             if (RobustTryParse(creature.Convince, out intVal)) { monster.ConvinceCost = intVal; }
-            if (RobustTryParse(creature.Illusionable, out boolVal)) { monster.Illusionable = boolVal; }
+            if (RobustTryParse(creature.Illusionable, out boolVal)) { monster.IsIllusionable = boolVal; }
             if (RobustTryParse(creature.IsBoss, out boolVal)) { monster.IsBoss = boolVal; }
             if (!string.IsNullOrWhiteSpace(creature.PrimaryType)) { monster.HideHealth = creature.PrimaryType.ToLower().Contains("trap"); }
-            if (RobustTryParse(creature.Pushable, out boolVal)) { monster.Pushable = boolVal; }
+            if (RobustTryParse(creature.Pushable, out boolVal)) { monster.IsPushable = boolVal; }
             // In cipbia ability to push objects means ability to push creatures too
             if (RobustTryParse(creature.PushObjects, out boolVal)) { monster.PushItems = monster.PushCreatures = boolVal; }
             if (RobustTryParse(creature.SenseInvis, out boolVal)) { monster.IgnoreInvisible = boolVal; }
@@ -1066,10 +1066,10 @@ namespace MonsterConverterTibiaWiki
                 $"| armor          = {monster.TotalArmor}",
                 string.Format("| summon         = {0}", monster.SummonCost > 0 ? monster.SummonCost.ToString() : "--"),
                 string.Format("| convince       = {0}", monster.ConvinceCost > 0 ? monster.ConvinceCost.ToString() : "--"),
-                string.Format("| illusionable   = {0}", monster.Illusionable ? "yes" : "no"),
+                string.Format("| illusionable   = {0}", monster.IsIllusionable ? "yes" : "no"),
                 string.Format("| primarytype    = {0}", monster.HideHealth ? "trap" : ""),
                 string.Format("| isboss         = {0}", monster.IsBoss ? "yes" : "no"),
-                string.Format("| pushable       = {0}", monster.Pushable ? "yes" : "no"),
+                string.Format("| pushable       = {0}", monster.IsPushable ? "yes" : "no"),
                 string.Format("| pushobjects    = {0}", monster.PushItems ? "yes" : "no"),
                 $"| walksaround    = {GenericToTibiaWikiWalkAround(ref monster)}",
                 $"| walksthrough   = {GenericToTibiaWikiWalkThrough(ref monster)}",

--- a/app/OTMonsterConverter.sln
+++ b/app/OTMonsterConverter.sln
@@ -15,9 +15,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonsterConverterTfsXml", "M
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonsterConverterTibiaWiki", "MonsterConverterTibiaWiki\MonsterConverterTibiaWiki.csproj", "{804873AF-3756-427F-A3C8-4565063AB039}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OTMonsterConverter", "OTMonsterConverter\OTMonsterConverter.csproj", "{9228A478-89C4-4277-AC0D-79B22D73B52B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OTMonsterConverter", "OTMonsterConverter\OTMonsterConverter.csproj", "{9228A478-89C4-4277-AC0D-79B22D73B52B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonsterConverterProcessor", "MonsterConverterProcessor\MonsterConverterProcessor.csproj", "{D1055769-6ED5-4860-9AA9-904395698A89}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonsterConverterProcessor", "MonsterConverterProcessor\MonsterConverterProcessor.csproj", "{D1055769-6ED5-4860-9AA9-904395698A89}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonsterConverterCipMon", "MonsterConverterCipMon\MonsterConverterCipMon.csproj", "{BFFA95C9-04F4-44A9-A4D4-7E160F09F73E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -57,6 +59,10 @@ Global
 		{D1055769-6ED5-4860-9AA9-904395698A89}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1055769-6ED5-4860-9AA9-904395698A89}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1055769-6ED5-4860-9AA9-904395698A89}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BFFA95C9-04F4-44A9-A4D4-7E160F09F73E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BFFA95C9-04F4-44A9-A4D4-7E160F09F73E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BFFA95C9-04F4-44A9-A4D4-7E160F09F73E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BFFA95C9-04F4-44A9-A4D4-7E160F09F73E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/app/otmc/ConsoleWindow.cs
+++ b/app/otmc/ConsoleWindow.cs
@@ -34,12 +34,12 @@ namespace otmc
 
         private void FileProcessor_OnMonsterConverted(object sender, FileProcessorEventArgs e)
         {
-            if ((e.Source.Code == ConvertError.Error) || (e.Source.Code == ConvertError.Error))
+            if ((e.Source.Code == ConvertError.Error) || (e.Destination.Code == ConvertError.Error))
             {
                 ConvertErrorCount++;
                 PrintInfo(ConvertError.Error, e.Source, e.Destination);
             }
-            else if ((e.Source.Code == ConvertError.Warning) || (e.Source.Code == ConvertError.Warning))
+            else if ((e.Source.Code == ConvertError.Warning) || (e.Destination.Code == ConvertError.Warning))
             {
                 ConvertWarningCount++;
                 PrintInfo(ConvertError.Warning, e.Source, e.Destination);


### PR DESCRIPTION
Closes #12 

Implement support for parsing the cip monster format, the main deficiency is that the item ids use the client ids instead of open tibia item ids.