### PR TITLE
[tibiawiki] Distinguish between conditions and elements when parsing abilities

### DIFF
--- a/app/MonsterConverterTibiaWiki/TemplateParser/TemplateParser.cs
+++ b/app/MonsterConverterTibiaWiki/TemplateParser/TemplateParser.cs
@@ -181,11 +181,10 @@ namespace MonsterConverterTibiaWiki
                 {
                     if (!indexedPropertyNames.ContainsKey(attr.BeforeCaptureProperty))
                     {
-                        System.Diagnostics.Debug.WriteLine($"template {templateName} no matching BeforeCaptureProperty found");
+                        //System.Diagnostics.Debug.WriteLine($"template {templateName} no matching BeforeCaptureProperty found");
                     }
                     else
                     {
-
                         prop = indexedPropertyNames[attr.BeforeCaptureProperty];
                         prop.SetValue(output, m.Groups["before"].Value.Trim(), null);
                     }
@@ -195,7 +194,7 @@ namespace MonsterConverterTibiaWiki
                 {
                     if (!indexedPropertyNames.ContainsKey(attr.AfterCaptureProperty))
                     {
-                        System.Diagnostics.Debug.WriteLine($"template {templateName} no matching AfterCaptureProperty found");
+                        //System.Diagnostics.Debug.WriteLine($"template {templateName} no matching AfterCaptureProperty found");
                     }
                     else
                     {
@@ -218,7 +217,7 @@ namespace MonsterConverterTibiaWiki
                             string parameterName = m.Groups["name"].Value.ToLower();
                             if (!indexedPropertyNames.ContainsKey(parameterName))
                             {
-                                System.Diagnostics.Debug.WriteLine($"template {templateName} index {parameterName} not parsed");
+                                //System.Diagnostics.Debug.WriteLine($"template {templateName} index {parameterName} not parsed");
                                 continue;
                             }
                             prop = indexedPropertyNames[parameterName];

--- a/app/MonsterConverterTibiaWiki/TibiaWikiConverter.cs
+++ b/app/MonsterConverterTibiaWiki/TibiaWikiConverter.cs
@@ -24,20 +24,20 @@ namespace MonsterConverterTibiaWiki
 
         private static readonly HttpClient httpClient = new HttpClient();
 
-        // <element name, damage type>
-        private static BiDictionary<string, CombatDamage> WikiToElements = new BiDictionary<string, CombatDamage>
+        // <damage type, element name>
+        private static Dictionary<CombatDamage, string> WikiToElements = new Dictionary<CombatDamage, string>
         {
-            {"physical", CombatDamage.Physical},
-            {"energy", CombatDamage.Energy},
-            {"earth", CombatDamage.Earth},
-            {"fire", CombatDamage.Fire},
-            {"life drain", CombatDamage.LifeDrain},
-            {"mana drain", CombatDamage.ManaDrain},
-            {"healing", CombatDamage.Healing},
-            {"drown", CombatDamage.Drown},
-            {"ice", CombatDamage.Ice},
-            {"holy", CombatDamage.Holy},
-            {"death", CombatDamage.Death}
+            {CombatDamage.Physical, "physical"},
+            {CombatDamage.Energy, "energy"},
+            {CombatDamage.Earth, "earth"},
+            {CombatDamage.Fire, "fire"},
+            {CombatDamage.LifeDrain, "life drain"},
+            {CombatDamage.ManaDrain, "mana drain"},
+            {CombatDamage.Healing, "healing"},
+            {CombatDamage.Drown, "drown"},
+            {CombatDamage.Ice, "ice"},
+            {CombatDamage.Holy, "holy"},
+            {CombatDamage.Death, "death"}
         };
 
         // <item name, data>

--- a/app/MonsterConverterTibiaWiki/TibiaWikiConverterInput.cs
+++ b/app/MonsterConverterTibiaWiki/TibiaWikiConverterInput.cs
@@ -1199,36 +1199,47 @@ namespace MonsterConverterTibiaWiki
                     {
                         spell.Name = "condition";
                         spell.Condition = ConditionType.Bleeding;
+                        spell.Tick = 4000;
                         break;
                     }
                 case "burning":
                     {
                         spell.Name = "condition";
                         spell.Condition = ConditionType.Fire;
+                        spell.Tick = 9000;
+                        //spell.StartDamage = 10;
                         break;
                     }
                 case "cursed":
                     {
                         spell.Name = "condition";
                         spell.Condition = ConditionType.Cursed;
+                        spell.Tick = 4000;
                         break;
                     }
                 case "dazzled":
                     {
                         spell.Name = "condition";
                         spell.Condition = ConditionType.Dazzled;
+                        spell.Tick = 11000;
                         break;
                     }
                 case "drowning":
                     {
                         spell.Name = "condition";
                         spell.Condition = ConditionType.Drown;
+                        spell.Tick = 6000; // Unknown tick
+                        //spell.StartDamage = 8;
+                        // Fixed damage and interval?
                         break;
                     }
                 case "electrified":
                     {
                         spell.Name = "condition";
                         spell.Condition = ConditionType.Energy;
+                        spell.Tick = 11000;
+                        spell.StartDamage = 25;
+                        // Fixed damage and interval?
                         break;
                     }
                 case "feared": break;
@@ -1236,6 +1247,8 @@ namespace MonsterConverterTibiaWiki
                     {
                         spell.Name = "condition";
                         spell.Condition = ConditionType.Freezing;
+                        spell.Tick = 8000; // Need confirmation TW says 4 turns
+                        // Fixed damage and interval?
                         break;
                     }
                 case "hexed": break;
@@ -1246,6 +1259,7 @@ namespace MonsterConverterTibiaWiki
                     {
                         spell.Name = "condition";
                         spell.Condition = ConditionType.Poison;
+                        spell.Tick = 4000;
                         break;
                     }
                 case "rooted": break;

--- a/app/MonsterConverterTibiaWiki/TibiaWikiConverterInput.cs
+++ b/app/MonsterConverterTibiaWiki/TibiaWikiConverterInput.cs
@@ -952,7 +952,6 @@ namespace MonsterConverterTibiaWiki
                         }
                         else if (TemplateParser.IsTemplateMatch<AbilityTemplate>(ability))
                         {
-                            // TODO, report errors converting abilities each ability should be a single error entry even if that ability has multiple problems use a single entry
                             var abilityObj = TemplateParser.Deserialize<AbilityTemplate>(ability);
                             if (TryParseScene(abilityObj.scene, out Spell spell))
                             {
@@ -968,6 +967,7 @@ namespace MonsterConverterTibiaWiki
                                 else if (spell.Name == "condition")
                                 {
                                     // Too hard to parse the none standard string entries. We need a standard condition ability template.
+                                    System.Diagnostics.Debug.WriteLine($"{mon.FileName} couldn't parse scene for ability \"{ability}\" since its a condition");
                                 }
                                 else if (spell.Name == "invisible")
                                 {
@@ -988,6 +988,10 @@ namespace MonsterConverterTibiaWiki
                                     spell.MaxSpeedChange = -400;
                                     spell.Duration = 20000;
                                     mon.Attacks.Add(spell);
+                                }
+                                else
+                                {
+                                    System.Diagnostics.Debug.WriteLine($"{mon.FileName} couldn't parse scene for ability \"{ability}\"");
                                 }
                             }
                             else

--- a/app/MonsterConverterTibiaWiki/TibiaWikiConverterInput.cs
+++ b/app/MonsterConverterTibiaWiki/TibiaWikiConverterInput.cs
@@ -1072,9 +1072,25 @@ namespace MonsterConverterTibiaWiki
                             {
                                 // Too hard to parse the none standard string entries. We need a standard condition ability template.
                             }
-                            else if (spell.Name == "combat")
+                            else if (spell.Name == "invisible")
                             {
-                                // Could guess defaults based on creature HP, EXP, and bestiary difficulty
+                                spell.SpellCategory = SpellCategory.Defensive;
+                                spell.Duration = 7500;
+                                mon.Attacks.Add(spell);
+                            }
+                            else if (spell.Name == "drunk")
+                            {
+                                spell.Drunkenness = 0.5;
+                                spell.Duration = 15000;
+                                mon.Attacks.Add(spell);
+                            }
+                            else if (spell.Name == "paralyze")
+                            {
+                                spell.Name = "speed";
+                                spell.MinSpeedChange = -400;
+                                spell.MaxSpeedChange = -400;
+                                spell.Duration = 20000;
+                                mon.Attacks.Add(spell);
                             }
                         }
                         else
@@ -1096,8 +1112,8 @@ namespace MonsterConverterTibiaWiki
             if (string.IsNullOrWhiteSpace(element))
                 element = "physical";
 
-            // Fill set of possible icons pulled from https://tibia.fandom.com/wiki/Template:Icon
-            // Most icons are expended to be invalid and not applicable to spells
+            // Full set of possible icons pulled from https://tibia.fandom.com/wiki/Template:Icon
+            // Most icons are expected to be invalid and not applicable to spells
             switch (element.ToLower()) {
                 case "armor": break;
                 case "charm": break;
@@ -1184,13 +1200,13 @@ namespace MonsterConverterTibiaWiki
                 case "paralyze":
                 case "slowed":
                     {
-                        spell.Name = "condition";
+                        spell.Name = "paralyze";
                         spell.Condition = ConditionType.Paralyze;
                         break;
                     }
                 case "drunk":
                     {
-                        spell.Name = "condition";
+                        spell.Name = "drunk";
                         spell.Condition = ConditionType.Drunk;
                         break;
                     }
@@ -1199,47 +1215,36 @@ namespace MonsterConverterTibiaWiki
                     {
                         spell.Name = "condition";
                         spell.Condition = ConditionType.Bleeding;
-                        spell.Tick = 4000;
                         break;
                     }
                 case "burning":
                     {
                         spell.Name = "condition";
                         spell.Condition = ConditionType.Fire;
-                        spell.Tick = 9000;
-                        //spell.StartDamage = 10;
                         break;
                     }
                 case "cursed":
                     {
                         spell.Name = "condition";
                         spell.Condition = ConditionType.Cursed;
-                        spell.Tick = 4000;
                         break;
                     }
                 case "dazzled":
                     {
                         spell.Name = "condition";
                         spell.Condition = ConditionType.Dazzled;
-                        spell.Tick = 11000;
                         break;
                     }
                 case "drowning":
                     {
                         spell.Name = "condition";
                         spell.Condition = ConditionType.Drown;
-                        spell.Tick = 6000; // Unknown tick
-                        //spell.StartDamage = 8;
-                        // Fixed damage and interval?
                         break;
                     }
                 case "electrified":
                     {
                         spell.Name = "condition";
                         spell.Condition = ConditionType.Energy;
-                        spell.Tick = 11000;
-                        spell.StartDamage = 25;
-                        // Fixed damage and interval?
                         break;
                     }
                 case "feared": break;
@@ -1247,8 +1252,6 @@ namespace MonsterConverterTibiaWiki
                     {
                         spell.Name = "condition";
                         spell.Condition = ConditionType.Freezing;
-                        spell.Tick = 8000; // Need confirmation TW says 4 turns
-                        // Fixed damage and interval?
                         break;
                     }
                 case "hexed": break;
@@ -1259,7 +1262,6 @@ namespace MonsterConverterTibiaWiki
                     {
                         spell.Name = "condition";
                         spell.Condition = ConditionType.Poison;
-                        spell.Tick = 4000;
                         break;
                     }
                 case "rooted": break;
@@ -1286,8 +1288,12 @@ namespace MonsterConverterTibiaWiki
                 case "ranged challenged": break;
                 case "sap strength": break;
                 case "expose weakness": break;
-                case "invisible": break;
-                case "invisibility": break;
+                case "invisible":
+                case "invisibility":
+                    {
+                        spell.Name = "invisible";
+                        break;
+                    }
                 case "teleport": break;
                 case "spellwand": break;
                 case "shapeshifting": break;

--- a/app/MonsterConverterTibiaWiki/TibiaWikiConverterOutput.cs
+++ b/app/MonsterConverterTibiaWiki/TibiaWikiConverterOutput.cs
@@ -268,9 +268,9 @@ namespace MonsterConverterTibiaWiki
                         melee.name = wikiName;
                     }
                     melee.damage = damage;
-                    if (WikiToElements.Reverse.ContainsKey(s.DamageElement))
+                    if (WikiToElements.ContainsKey(s.DamageElement))
                     {
-                        melee.element = WikiToElements.Reverse[s.DamageElement];
+                        melee.element = WikiToElements[s.DamageElement];
                     }
                     melee.scene = GenericSpellToScene(s, mon.Name);
                     abilities.Add(TemplateParser.Serialize(melee));
@@ -300,7 +300,7 @@ namespace MonsterConverterTibiaWiki
                         wikiName = "Creates [[Fire Field|Fire]]";
                     }
                     ability.name = wikiName;
-                    ability.element = WikiToElements.Reverse[CombatDamage.Fire];
+                    ability.element = WikiToElements[CombatDamage.Fire];
                     ability.scene = GenericSpellToScene(s, mon.Name, "Fire");
                     abilities.Add(TemplateParser.Serialize(ability));
                 }
@@ -312,7 +312,7 @@ namespace MonsterConverterTibiaWiki
                         wikiName = "Creates [[Energy Field|Energy_Field_(Field)]]";
                     }
                     ability.name = wikiName;
-                    ability.element = WikiToElements.Reverse[CombatDamage.Energy];
+                    ability.element = WikiToElements[CombatDamage.Energy];
                     ability.scene = GenericSpellToScene(s, mon.Name, "Energy_Field_(Field)");
                     abilities.Add(TemplateParser.Serialize(ability));
                 }
@@ -324,7 +324,7 @@ namespace MonsterConverterTibiaWiki
                         wikiName = "Creates [[Poison Field|Poison_Gas]]";
                     }
                     ability.name = wikiName;
-                    ability.element = WikiToElements.Reverse[CombatDamage.Earth];
+                    ability.element = WikiToElements[CombatDamage.Earth];
                     ability.scene = GenericSpellToScene(s, mon.Name, "Poison_Gas");
                     abilities.Add(TemplateParser.Serialize(ability));
                 }
@@ -348,13 +348,21 @@ namespace MonsterConverterTibiaWiki
                         AbilityTemplate ability = new AbilityTemplate();
                         ability.name = wikiName;
                         ability.damage = damage;
-                        if (WikiToElements.Reverse.ContainsKey(s.DamageElement))
+                        if (WikiToElements.ContainsKey(s.DamageElement))
                         {
-                            ability.element = WikiToElements.Reverse[s.DamageElement];
+                            ability.element = WikiToElements[s.DamageElement];
                         }
                         ability.scene = GenericSpellToScene(s, mon.Name);
                         abilities.Add(TemplateParser.Serialize(ability));
                     }
+                }
+                else if (s.Name == "condition")
+                {
+                    AbilityTemplate ability = new AbilityTemplate();
+                    ability.name = wikiName;
+                    // condition crap is mostly in a random string
+                    ability.scene = GenericSpellToScene(s, mon.Name);
+                    abilities.Add(TemplateParser.Serialize(ability));
                 }
                 else if (s.Name == "invisible")
                 {

--- a/app/MonsterConverterTibiaWiki/TibiaWikiTemplates/InfoboxCreatureTemplate.cs
+++ b/app/MonsterConverterTibiaWiki/TibiaWikiTemplates/InfoboxCreatureTemplate.cs
@@ -56,6 +56,9 @@
         [TemplateParameter(Index = 18, Required = ParameterRequired.No, Indicator = ParameterIndicator.Name)]
         public string attacktype { get; set; }
 
+        [TemplateParameter(Index = 19, Required = ParameterRequired.No, Indicator = ParameterIndicator.Name)]
+        public string usespells { get; set; }
+
         [TemplateParameter(Index = 20, Required = ParameterRequired.No, Indicator = ParameterIndicator.Name)]
         public string spawntype { get; set; }
 


### PR DESCRIPTION
Closes #67 

It turns out the element field uses both condition terms and elemental damage type terms such as "poisoned", "poison", "earth". This subtle difference is used to distinguish between condition and damage spells. With this diff parsing damage spells is more accurate. 